### PR TITLE
change registry from GitHub to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,6 @@ env:
 permissions:
   contents: write
   pull-requests: write
-  packages: write
 
 jobs:
   Build-and-Release:
@@ -47,7 +46,7 @@ jobs:
       - name: NPM Publish
         run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         if: ${{ steps.release.outputs.release_created }}
       - name: Notify new release to Slack
         id: slack

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-@deven-org:registry=https://npm.pkg.github.com
+@deven-org:registry=https://registry.npmjs.com
 registry=https://registry.npmjs.com

--- a/README.md
+++ b/README.md
@@ -74,40 +74,16 @@ The purpose of this "documentation skeleton" project is to provide a simple way 
 
 To install the package in your project follow these steps:
 
-1. add the Github registry for the @deven-org scope:
+install the package:
+  
+```bash
+npm install @deven-org/documentation-skeleton --save-dev
+```
+or
 
-    ```bash
-    npm config set @deven-org:registry=https://npm.pkg.github.com/ --location project
-    ```
-
-2. authenticate towards the Github registry (if you are not already):
-
-    1. create a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
-
-        * we recommend to use the "classic" token interface
-        * minimum scope that needs to be set is `read:packages`
-
-    2. login to the Github registry
-        * with npm
-            ```bash
-            npm login --scope=@deven-org --registry=https://npm.pkg.github.com/
-            ```
-
-        * with yarn
-            ```bash
-            yarn npm login --scope my-scope
-            ```
-
-3. install the package:
-    * with npm
-        ```bash
-        npm install @deven-org/documentation-skeleton --save-dev
-        ```
-
-    * with yarn
-        ```bash
-        yarn add @deven-org/documentation-skeleton --dev
-        ```
+```bash
+yarn add @deven-org/documentation-skeleton --dev
+```
 
 Add the following entries to your `package.json` scripts section:
 

--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
     "type": "git",
     "url": "https://github.com/deven-org/documentation-skeleton.git"
   },
-  "publishConfig": {
-    "@deven-org:registry": "https://npm.pkg.github.com"
-  },
   "keywords": [
     "deven",
     "documentation"


### PR DESCRIPTION
Package registry was changed.
Also added a new secret with a new NPM access token that has only access to write to the DS package and is valid for one year. 